### PR TITLE
Center mobile layout and fix viewport settings

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
+    <meta name="viewport" content="width=430, initial-scale=1.0, user-scalable=no, viewport-fit=cover" />
     
     <!-- PWA Manifest -->
     <link rel="manifest" href="/manifest.json" />

--- a/src/components/layout/MobileFrame.tsx
+++ b/src/components/layout/MobileFrame.tsx
@@ -8,7 +8,9 @@ interface MobileFrameProps {
 // Completely frameless container - no phone mockup styling
 const FullScreenContainer = styled.div`
   /* Full viewport dimensions - edge to edge */
-  width: 100vw;
+  width: 100%;
+  max-width: 430px;
+  margin: 0 auto;
   height: 100vh;
   min-height: 100vh;
   position: relative;
@@ -20,7 +22,6 @@ const FullScreenContainer = styled.div`
   
   /* Remove any background or padding */
   background: transparent;
-  margin: 0;
   padding: 0;
 `;
 

--- a/src/styles/GlobalStyle.ts
+++ b/src/styles/GlobalStyle.ts
@@ -27,6 +27,8 @@ export const GlobalStyle = createGlobalStyle`
     line-height: 1.5;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+    display: flex;
+    justify-content: center;
   }
   
   /* Use app background on mobile */
@@ -39,10 +41,11 @@ export const GlobalStyle = createGlobalStyle`
   #root {
     min-height: 100vh;
     height: 100vh;
-    width: 100vw;
+    width: 100%;
+    max-width: 430px;
     display: flex;
     flex-direction: column;
-    margin: 0;
+    margin: 0 auto;
     padding: 0;
   }
   


### PR DESCRIPTION
## Summary
- Center app content in body and limit #root width to 430px
- Apply same width constraint to `MobileFrame`
- Fix viewport meta tag to enforce 430px width

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 21 errors, e.g. unexpected any types and hook usage)*

------
https://chatgpt.com/codex/tasks/task_e_68af2bb9004c83219a1256a4a2747644