### PR TITLE
feat: implement chat conversation

### DIFF
--- a/src/pages/ChatScreen.tsx
+++ b/src/pages/ChatScreen.tsx
@@ -1,52 +1,107 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
-import { motion } from 'framer-motion';
+import { useParams } from 'react-router-dom';
+import { useAppStore } from '../stores/appStore';
+import { Button } from '../components/common/Button';
 
 const ChatContainer = styled.div`
   min-height: calc(100vh - 130px);
   background: ${props => props.theme.current.colors.background};
   display: flex;
   flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  padding: ${props => props.theme.common.spacing.lg};
+  padding: ${props => props.theme.common.spacing.md};
 `;
 
-const ComingSoonContent = styled(motion.div)`
-  text-align: center;
-  color: ${props => props.theme.current.colors.textSecondary};
+const MessagesList = styled.div`
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: ${props => props.theme.common.spacing.sm};
+  overflow-y: auto;
 `;
 
-const Icon = styled.div`
-  font-size: 4rem;
-  margin-bottom: ${props => props.theme.common.spacing.lg};
-`;
-
-const Title = styled.h2`
-  font-size: ${props => props.theme.common.typography.fontSize.xl};
+const MessageBubble = styled.div<{ $isOwn: boolean }>`
+  max-width: 80%;
+  align-self: ${props => (props.$isOwn ? 'flex-end' : 'flex-start')};
+  background: ${props =>
+    props.$isOwn
+      ? props.theme.current.gradients.main
+      : props.theme.current.colors.surface};
   color: ${props => props.theme.current.colors.text};
-  margin-bottom: ${props => props.theme.common.spacing.md};
+  padding: ${props =>
+    `${props.theme.common.spacing.sm} ${props.theme.common.spacing.md}`};
+  border-radius: ${props => props.theme.common.borderRadius.large};
 `;
 
-const Description = styled.p`
-  font-size: ${props => props.theme.common.typography.fontSize.md};
-  margin-bottom: ${props => props.theme.common.spacing.lg};
+const InputContainer = styled.form`
+  display: flex;
+  gap: ${props => props.theme.common.spacing.sm};
+  margin-top: ${props => props.theme.common.spacing.md};
+`;
+
+const MessageInput = styled.input`
+  flex: 1;
+  padding: ${props => props.theme.common.spacing.sm};
+  border: 1px solid ${props => props.theme.current.colors.primary}30;
+  border-radius: ${props => props.theme.common.borderRadius.large};
+  background: ${props => props.theme.current.colors.surface};
+  color: ${props => props.theme.current.colors.text};
+
+  &:focus {
+    outline: none;
+    border-color: ${props => props.theme.current.colors.primary};
+  }
 `;
 
 export const ChatScreen: React.FC = () => {
+  const { matchId } = useParams<{ matchId: string }>();
+  const { matches, currentUser, sendMessage } = useAppStore();
+  const match = matches.find(m => m.id === matchId);
+  const [content, setContent] = useState('');
+
+  if (!match) {
+    return <ChatContainer>Match not found</ChatContainer>;
+  }
+
+  const handleSend = () => {
+    const trimmed = content.trim();
+    if (!trimmed) return;
+    sendMessage(match.id, {
+      senderId: currentUser.id,
+      content: trimmed,
+      type: 'text',
+    });
+    setContent('');
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    handleSend();
+  };
+
   return (
     <ChatContainer>
-      <ComingSoonContent
-        initial={{ opacity: 0, y: 20 }}
-        animate={{ opacity: 1, y: 0 }}
-      >
-        <Icon>💬</Icon>
-        <Title>Chat Coming Soon!</Title>
-        <Description>
-          Individual chat functionality will be implemented next.
-          Stay tuned for drag-themed conversations!
-        </Description>
-      </ComingSoonContent>
+      <MessagesList>
+        {match.conversation.map(message => (
+          <MessageBubble
+            key={message.id}
+            $isOwn={message.senderId === currentUser.id}
+          >
+            {message.content}
+          </MessageBubble>
+        ))}
+      </MessagesList>
+      <InputContainer onSubmit={handleSubmit}>
+        <MessageInput
+          value={content}
+          onChange={e => setContent(e.target.value)}
+          placeholder="Type a message"
+        />
+        <Button type="submit" variant="primary">
+          Send
+        </Button>
+      </InputContainer>
     </ChatContainer>
   );
 };
+


### PR DESCRIPTION
## Summary
- implement chat screen to display conversation and send messages
- style message bubbles based on sender and add input form with send button

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af3da954b48321b8703d4efcb5d926