### PR TITLE
Track given and received likes for swipe matches

### DIFF
--- a/src/pages/HomeScreen.tsx
+++ b/src/pages/HomeScreen.tsx
@@ -203,10 +203,12 @@ const SuperLikeAnimation = styled(motion.div)`
 `;
 
 export const HomeScreen: React.FC = () => {
-  const { 
-    profiles, 
-    currentProfileIndex, 
-    swipeProfile 
+  const {
+    profiles,
+    currentProfileIndex,
+    swipeProfile,
+    addLikeGiven,
+    receiveLike
   } = useAppStore();
   const navigate = useNavigate();
   
@@ -230,13 +232,17 @@ export const HomeScreen: React.FC = () => {
       setSuperLikeAnimation(direction === 'boots' ? '👠' : '💇‍♀️');
       setTimeout(() => setSuperLikeAnimation(null), 1500);
     }
-    if ((direction === 'right' || direction === 'boots' || direction === 'wig') && Math.random() > 0.7) {
-      setMatchedProfile(currentProfile);
-      setShowMatch(true);
-      setTimeout(() => {
-        setShowMatch(false);
-        setMatchedProfile(null);
-      }, 3000);
+    if (direction === 'right' || direction === 'boots' || direction === 'wig') {
+      addLikeGiven(currentProfile.vibe);
+      if (Math.random() > 0.7) {
+        setMatchedProfile(currentProfile);
+        setShowMatch(true);
+        receiveLike(currentProfile.vibe);
+        setTimeout(() => {
+          setShowMatch(false);
+          setMatchedProfile(null);
+        }, 3000);
+      }
     }
     swipeProfile({
       type: direction === 'left' ? 'pass' : direction === 'right' ? 'like' : direction,

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -63,7 +63,8 @@ interface AppState {
   profiles: Profile[];
   matches: Match[];
   currentProfileIndex: number;
-  likesByVibe: Record<VibeType, number>;
+  likesGivenByVibe: Record<VibeType, number>;
+  likesReceivedByVibe: Record<VibeType, number>;
 
   // Actions
   setCurrentVibe: (vibe: VibeType) => void;
@@ -72,7 +73,8 @@ interface AppState {
   sendMessage: (matchId: string, message: Omit<Message, 'id' | 'timestamp'>) => void;
   nextProfile: () => void;
   resetSwipeStack: () => void;
-  addLike: (vibe: VibeType) => void;
+  addLikeGiven: (vibe: VibeType) => void;
+  receiveLike: (vibe: VibeType) => void;
   resetLikes: () => void;
   hasBingo: () => boolean;
 }
@@ -92,7 +94,8 @@ export const useAppStore = create<AppState>((set, get) => ({
   profiles: [],
   matches: [],
   currentProfileIndex: 0,
-  likesByVibe: { ...emptyLikes },
+  likesGivenByVibe: { ...emptyLikes },
+  likesReceivedByVibe: { ...emptyLikes },
 
   // Actions
   setCurrentVibe: (vibe: VibeType) => set({ currentVibe: vibe }),
@@ -150,18 +153,29 @@ export const useAppStore = create<AppState>((set, get) => ({
   })),
 
   resetSwipeStack: () => set({ currentProfileIndex: 0 }),
-  addLike: (vibe: VibeType) =>
+  addLikeGiven: (vibe: VibeType) =>
     set((state) => ({
-      likesByVibe: {
-        ...state.likesByVibe,
-        [vibe]: state.likesByVibe[vibe] + 1,
+      likesGivenByVibe: {
+        ...state.likesGivenByVibe,
+        [vibe]: state.likesGivenByVibe[vibe] + 1,
+      },
+    })),
+  receiveLike: (vibe: VibeType) =>
+    set((state) => ({
+      likesReceivedByVibe: {
+        ...state.likesReceivedByVibe,
+        [vibe]: state.likesReceivedByVibe[vibe] + 1,
       },
     })),
 
-  resetLikes: () => set({ likesByVibe: { ...emptyLikes } }),
+  resetLikes: () =>
+    set({
+      likesGivenByVibe: { ...emptyLikes },
+      likesReceivedByVibe: { ...emptyLikes },
+    }),
 
   hasBingo: () => {
-    const likes = get().likesByVibe;
+    const likes = get().likesGivenByVibe;
     return Object.values(likes).every((count) => count > 0);
   },
 }));

--- a/test/likesFlow.test.ts
+++ b/test/likesFlow.test.ts
@@ -1,0 +1,52 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { useAppStore } from '../src/stores/appStore.ts';
+
+test('addLikeGiven increments count', () => {
+  const empty = { spicy: 0, chill: 0, urban: 0, artsy: 0, dluxe: 0 };
+  useAppStore.setState({ likesGivenByVibe: { ...empty }, likesReceivedByVibe: { ...empty } });
+  const { addLikeGiven } = useAppStore.getState();
+  addLikeGiven('spicy');
+  assert.equal(useAppStore.getState().likesGivenByVibe.spicy, 1);
+});
+
+test('receiveLike increments count', () => {
+  const empty = { spicy: 0, chill: 0, urban: 0, artsy: 0, dluxe: 0 };
+  useAppStore.setState({ likesReceivedByVibe: { ...empty } });
+  const { receiveLike } = useAppStore.getState();
+  receiveLike('chill');
+  assert.equal(useAppStore.getState().likesReceivedByVibe.chill, 1);
+});
+
+test('match flow adds given and received like when random allows match', () => {
+  const empty = { spicy: 0, chill: 0, urban: 0, artsy: 0, dluxe: 0 };
+  useAppStore.setState({
+    profiles: [{
+      id: '1',
+      name: 'Test',
+      age: 20,
+      vibe: 'urban',
+      bio: '',
+      images: [],
+      personality: { style: '', catchphrase: '', interests: [], signature_move: '' }
+    }],
+    currentProfileIndex: 0,
+    likesGivenByVibe: { ...empty },
+    likesReceivedByVibe: { ...empty }
+  });
+
+  const { addLikeGiven, receiveLike } = useAppStore.getState();
+  const originalRandom = Math.random;
+  Math.random = () => 0.9;
+
+  const profile = useAppStore.getState().profiles[0];
+  addLikeGiven(profile.vibe);
+  if (Math.random() > 0.7) {
+    receiveLike(profile.vibe);
+  }
+
+  assert.equal(useAppStore.getState().likesGivenByVibe.urban, 1);
+  assert.equal(useAppStore.getState().likesReceivedByVibe.urban, 1);
+
+  Math.random = originalRandom;
+});


### PR DESCRIPTION
## Summary
- Track likes given and likes received in app store
- Update HomeScreen swipe flow to record likes and received likes on matches
- Add tests for like tracking with mocked Math.random

## Testing
- `NODE_OPTIONS=--experimental-strip-types npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af520011a08321a46b036b6db6e579