### PR TITLE
Add Bingo reward modal with badge unlocking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "framer-motion": "^12.23.12",
         "lucide-react": "^0.541.0",
         "react": "^19.1.1",
+        "react-confetti": "^6.4.0",
         "react-dom": "^19.1.1",
         "react-hook-form": "^7.62.0",
         "react-router-dom": "^7.8.2",
@@ -3038,6 +3039,21 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-confetti": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/react-confetti/-/react-confetti-6.4.0.tgz",
+      "integrity": "sha512-5MdGUcqxrTU26I2EU7ltkWPwxvucQTuqMm8dUz72z2YMqTD6s9vMcDUysk7n9jnC+lXuCPeJJ7Knf98VEYE9Rg==",
+      "license": "MIT",
+      "dependencies": {
+        "tween-functions": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "react": "^16.3.0 || ^17.0.1 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/react-dom": {
       "version": "19.1.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.1.tgz",
@@ -3439,6 +3455,12 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tween-functions": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tween-functions/-/tween-functions-1.2.0.tgz",
+      "integrity": "sha512-PZBtLYcCLtEcjL14Fzb1gSxPBeL7nWvGhO5ZFPGqziCcr8uvHp0NDmdjBchp6KHL+tExcg0m3NISmKxhU394dA==",
+      "license": "BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "framer-motion": "^12.23.12",
     "lucide-react": "^0.541.0",
     "react": "^19.1.1",
+    "react-confetti": "^6.4.0",
     "react-dom": "^19.1.1",
     "react-hook-form": "^7.62.0",
     "react-router-dom": "^7.8.2",

--- a/src/components/modals/BingoRewardModal.tsx
+++ b/src/components/modals/BingoRewardModal.tsx
@@ -1,0 +1,105 @@
+import React, { useEffect, useState } from 'react';
+import styled from 'styled-components';
+import { AnimatePresence, motion } from 'framer-motion';
+import { X } from 'lucide-react';
+import { Button } from '../common/Button';
+import { useAppStore } from '../../stores/appStore';
+
+interface BingoRewardModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const ModalOverlay = styled(motion.div)`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.8);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+const ModalContent = styled(motion.div)`
+  background: ${(props) => props.theme.current.colors.background};
+  border-radius: ${(props) => props.theme.common.borderRadius.large};
+  padding: ${(props) => props.theme.common.spacing.lg};
+  width: 90%;
+  max-width: 320px;
+  text-align: center;
+  position: relative;
+`;
+
+const CloseButton = styled(motion.button)`
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  background: transparent;
+  border: none;
+  color: ${(props) => props.theme.current.colors.text};
+  cursor: pointer;
+`;
+
+const Title = styled.h3`
+  margin: 0 0 ${(props) => props.theme.common.spacing.md} 0;
+  color: ${(props) => props.theme.current.colors.text};
+`;
+
+const Message = styled.p`
+  margin-bottom: ${(props) => props.theme.common.spacing.lg};
+  color: ${(props) => props.theme.current.colors.text};
+`;
+
+export const BingoRewardModal: React.FC<BingoRewardModalProps> = ({ isOpen, onClose }) => {
+  const unlockBingoBadge = useAppStore((state) => state.unlockBingoBadge);
+  const [Confetti, setConfetti] = useState<React.ComponentType | null>(null);
+
+  useEffect(() => {
+    if (isOpen && typeof window !== 'undefined') {
+      import('react-confetti').then((mod) => setConfetti(() => mod.default));
+    }
+  }, [isOpen]);
+
+  const handleClose = () => {
+    unlockBingoBadge();
+    onClose();
+  };
+
+  return (
+    <AnimatePresence>
+      {isOpen && (
+        <ModalOverlay
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          onClick={handleClose}
+        >
+          {Confetti && <Confetti recycle={false} numberOfPieces={300} />}
+          <ModalContent
+            initial={{ scale: 0.8 }}
+            animate={{ scale: 1 }}
+            exit={{ scale: 0.8 }}
+            transition={{ type: 'spring', stiffness: 300, damping: 30 }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <CloseButton
+              onClick={handleClose}
+              whileHover={{ scale: 1.1 }}
+              whileTap={{ scale: 0.9 }}
+            >
+              <X size={24} />
+            </CloseButton>
+            <Title>Bingo!</Title>
+            <Message>You have liked all vibes. Badge unlocked!</Message>
+            <Button onClick={handleClose}>Cerrar</Button>
+          </ModalContent>
+        </ModalOverlay>
+      )}
+    </AnimatePresence>
+  );
+};
+
+export default BingoRewardModal;

--- a/src/pages/LikesScreen.tsx
+++ b/src/pages/LikesScreen.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import styled, { css } from 'styled-components';
 import { motion } from 'framer-motion';
 import { useAppStore } from '../stores/appStore';
 import type { VibeType } from '../styles/themes/types';
 import { Button } from '../components/common/Button';
+import BingoRewardModal from '../components/modals/BingoRewardModal';
 
 const LikesContainer = styled.div`
   padding: ${props => props.theme.common.spacing.lg};
@@ -55,14 +56,27 @@ const Counts = styled.span`
 `;
 
 export const LikesScreen: React.FC = () => {
-  const { likesGivenByVibe, likesReceivedByVibe, resetLikes } = useAppStore();
+  const {
+    likesGivenByVibe,
+    likesReceivedByVibe,
+    resetLikes,
+    hasBingo,
+    bingoBadgeUnlocked,
+  } = useAppStore();
   const vibes: VibeType[] = ['spicy', 'chill', 'urban', 'artsy', 'dluxe'];
+  const [showModal, setShowModal] = useState(false);
+
+  useEffect(() => {
+    if (hasBingo() && !bingoBadgeUnlocked) {
+      setShowModal(true);
+    }
+  }, [likesGivenByVibe, hasBingo, bingoBadgeUnlocked]);
 
   return (
     <LikesContainer>
       <Title>Likes</Title>
       <VibeList>
-        {vibes.map(vibe => {
+        {vibes.map((vibe) => {
           const given = likesGivenByVibe[vibe];
           const received = likesReceivedByVibe[vibe];
           const total = given + received;
@@ -88,6 +102,7 @@ export const LikesScreen: React.FC = () => {
       <Button variant="secondary" onClick={resetLikes}>
         Reset Likes
       </Button>
+      <BingoRewardModal isOpen={showModal} onClose={() => setShowModal(false)} />
     </LikesContainer>
   );
 };

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -65,6 +65,7 @@ interface AppState {
   currentProfileIndex: number;
   likesGivenByVibe: Record<VibeType, number>;
   likesReceivedByVibe: Record<VibeType, number>;
+  bingoBadgeUnlocked: boolean;
 
   // Actions
   setCurrentVibe: (vibe: VibeType) => void;
@@ -76,6 +77,7 @@ interface AppState {
   addLikeGiven: (vibe: VibeType) => void;
   receiveLike: (vibe: VibeType) => void;
   resetLikes: () => void;
+  unlockBingoBadge: () => void;
   hasBingo: () => boolean;
 }
 
@@ -96,6 +98,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   currentProfileIndex: 0,
   likesGivenByVibe: { ...emptyLikes },
   likesReceivedByVibe: { ...emptyLikes },
+  bingoBadgeUnlocked: false,
 
   // Actions
   setCurrentVibe: (vibe: VibeType) => set({ currentVibe: vibe }),
@@ -172,7 +175,10 @@ export const useAppStore = create<AppState>((set, get) => ({
     set({
       likesGivenByVibe: { ...emptyLikes },
       likesReceivedByVibe: { ...emptyLikes },
+      bingoBadgeUnlocked: false,
     }),
+
+  unlockBingoBadge: () => set({ bingoBadgeUnlocked: true }),
 
   hasBingo: () => {
     const likes = get().likesGivenByVibe;


### PR DESCRIPTION
## Summary
- add BingoRewardModal using framer-motion and confetti effects
- show modal in LikesScreen when all vibes are liked and unlock badge in store
- track bingo badge state in app store and reset on likes reset

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af548cd23083218b729a9ef8f50169