### PR TITLE
feat: add fireworks effect to bingo reward

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "vibes",
       "version": "0.0.0",
       "dependencies": {
+        "canvas-confetti": "^1.9.3",
         "framer-motion": "^12.23.12",
         "lucide-react": "^0.541.0",
         "react": "^19.1.1",
@@ -20,6 +21,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.33.0",
+        "@types/canvas-confetti": "^1.9.0",
         "@types/react": "^19.1.10",
         "@types/react-dom": "^19.1.7",
         "@types/styled-components": "^5.1.34",
@@ -1421,6 +1423,13 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/canvas-confetti": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@types/canvas-confetti/-/canvas-confetti-1.9.0.tgz",
+      "integrity": "sha512-aBGj/dULrimR1XDZLtG9JwxX1b4HPRF6CX9Yfwh3NvstZEm1ZL7RBnel4keCPSqs1ANRu1u2Aoz9R+VmtjYuTg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1944,6 +1953,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canvas-confetti": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/canvas-confetti/-/canvas-confetti-1.9.3.tgz",
+      "integrity": "sha512-rFfTURMvmVEX1gyXFgn5QMn81bYk70qa0HLzcIOSVEyl57n6o9ItHeBtUSWdvKAPY0xlvBHno4/v3QPrT83q9g==",
+      "license": "ISC",
+      "funding": {
+        "type": "donate",
+        "url": "https://www.paypal.me/kirilvatev"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test": "node --test"
   },
   "dependencies": {
+    "canvas-confetti": "^1.9.3",
     "framer-motion": "^12.23.12",
     "lucide-react": "^0.541.0",
     "react": "^19.1.1",
@@ -23,6 +24,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",
+    "@types/canvas-confetti": "^1.9.0",
     "@types/react": "^19.1.10",
     "@types/react-dom": "^19.1.7",
     "@types/styled-components": "^5.1.34",

--- a/src/components/modals/BingoRewardModal.tsx
+++ b/src/components/modals/BingoRewardModal.tsx
@@ -55,12 +55,49 @@ const Message = styled.p`
 
 export const BingoRewardModal: React.FC<BingoRewardModalProps> = ({ isOpen, onClose }) => {
   const unlockBingoBadge = useAppStore((state) => state.unlockBingoBadge);
-  const [Confetti, setConfetti] = useState<React.ComponentType | null>(null);
+  const [Confetti, setConfetti] = useState<React.ComponentType<any> | null>(null);
 
   useEffect(() => {
+    let interval: number | undefined;
     if (isOpen && typeof window !== 'undefined') {
       import('react-confetti').then((mod) => setConfetti(() => mod.default));
+      import('canvas-confetti').then((mod) => {
+        const duration = 3 * 1000;
+        const animationEnd = Date.now() + duration;
+        const defaults = { startVelocity: 30, spread: 360, ticks: 60, zIndex: 2000 };
+
+        function randomInRange(min: number, max: number) {
+          return Math.random() * (max - min) + min;
+        }
+
+        interval = window.setInterval(() => {
+          const timeLeft = animationEnd - Date.now();
+
+          if (timeLeft <= 0 && interval) {
+            window.clearInterval(interval);
+            return;
+          }
+
+          const particleCount = 50 * (timeLeft / duration);
+          mod.default({
+            ...defaults,
+            particleCount,
+            origin: { x: randomInRange(0.1, 0.3), y: Math.random() - 0.2 },
+          });
+          mod.default({
+            ...defaults,
+            particleCount,
+            origin: { x: randomInRange(0.7, 0.9), y: Math.random() - 0.2 },
+          });
+        }, 250);
+      });
     }
+
+    return () => {
+      if (interval) {
+        window.clearInterval(interval);
+      }
+    };
   }, [isOpen]);
 
   const handleClose = () => {
@@ -77,7 +114,9 @@ export const BingoRewardModal: React.FC<BingoRewardModalProps> = ({ isOpen, onCl
           exit={{ opacity: 0 }}
           onClick={handleClose}
         >
-          {Confetti && <Confetti recycle={false} numberOfPieces={300} />}
+          {Confetti && (
+            <Confetti recycle={false} numberOfPieces={800} gravity={0.3} />
+          )}
           <ModalContent
             initial={{ scale: 0.8 }}
             animate={{ scale: 1 }}


### PR DESCRIPTION
## Summary
- add canvas-confetti fireworks to BingoRewardModal
- boost confetti visuals with more pieces and gravity
- include canvas-confetti type definitions

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af57c2ea608321a267366c19b6e7f6