### PR TITLE
Make swipe matches deterministic

### DIFF
--- a/src/components/modals/BingoRewardModal.tsx
+++ b/src/components/modals/BingoRewardModal.tsx
@@ -55,7 +55,7 @@ const Message = styled.p`
 
 export const BingoRewardModal: React.FC<BingoRewardModalProps> = ({ isOpen, onClose }) => {
   const unlockBingoBadge = useAppStore((state) => state.unlockBingoBadge);
-  const [Confetti, setConfetti] = useState<React.ComponentType<any> | null>(null);
+  const [Confetti, setConfetti] = useState<React.ComponentType<unknown> | null>(null);
 
   useEffect(() => {
     let interval: number | undefined;

--- a/src/pages/HomeScreen.tsx
+++ b/src/pages/HomeScreen.tsx
@@ -234,15 +234,13 @@ export const HomeScreen: React.FC = () => {
     }
     if (direction === 'right' || direction === 'boots' || direction === 'wig') {
       addLikeGiven(currentProfile.vibe);
-      if (Math.random() > 0.7) {
-        setMatchedProfile(currentProfile);
-        setShowMatch(true);
-        receiveLike(currentProfile.vibe);
-        setTimeout(() => {
-          setShowMatch(false);
-          setMatchedProfile(null);
-        }, 3000);
-      }
+      setMatchedProfile(currentProfile);
+      setShowMatch(true);
+      receiveLike(currentProfile.vibe);
+      setTimeout(() => {
+        setShowMatch(false);
+        setMatchedProfile(null);
+      }, 3000);
     }
     swipeProfile({
       type: direction === 'left' ? 'pass' : direction === 'right' ? 'like' : direction,

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -108,10 +108,7 @@ export const useAppStore = create<AppState>((set, get) => ({
     const profile = state.profiles[state.currentProfileIndex];
     
     if (action.type === 'boots' || action.type === 'wig' || action.type === 'like') {
-      // Simulate match (for demo purposes, let's say 30% match rate)
-      if (Math.random() > 0.7) {
-        get().addMatch(profile);
-      }
+      get().addMatch(profile);
     }
     
     get().nextProfile();

--- a/test/likesFlow.test.ts
+++ b/test/likesFlow.test.ts
@@ -18,7 +18,7 @@ test('receiveLike increments count', () => {
   assert.equal(useAppStore.getState().likesReceivedByVibe.chill, 1);
 });
 
-test('match flow adds given and received like when random allows match', () => {
+test('match flow always adds given and received like and creates a match', () => {
   const empty = { spicy: 0, chill: 0, urban: 0, artsy: 0, dluxe: 0 };
   useAppStore.setState({
     profiles: [{
@@ -31,22 +31,18 @@ test('match flow adds given and received like when random allows match', () => {
       personality: { style: '', catchphrase: '', interests: [], signature_move: '' }
     }],
     currentProfileIndex: 0,
+    matches: [],
     likesGivenByVibe: { ...empty },
     likesReceivedByVibe: { ...empty }
   });
 
-  const { addLikeGiven, receiveLike } = useAppStore.getState();
-  const originalRandom = Math.random;
-  Math.random = () => 0.9;
-
+  const { addLikeGiven, receiveLike, swipeProfile } = useAppStore.getState();
   const profile = useAppStore.getState().profiles[0];
   addLikeGiven(profile.vibe);
-  if (Math.random() > 0.7) {
-    receiveLike(profile.vibe);
-  }
+  receiveLike(profile.vibe);
+  swipeProfile({ type: 'like', profileId: profile.id, timestamp: new Date() });
 
   assert.equal(useAppStore.getState().likesGivenByVibe.urban, 1);
   assert.equal(useAppStore.getState().likesReceivedByVibe.urban, 1);
-
-  Math.random = originalRandom;
+  assert.equal(useAppStore.getState().matches.length, 1);
 });


### PR DESCRIPTION
## Summary
- Remove random match logic from app store's swipeProfile and always add match for like/boots/wig actions
- Ensure HomeScreen handleSwipe always triggers match flow on right/boots/wig swipes
- Update likes flow tests for deterministic behavior
- Replace `any` with `unknown` in BingoRewardModal's confetti component to satisfy linting

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af5a105c848321b8c5d31d105c3026