### PR TITLE
feat: improve swipe detection

### DIFF
--- a/src/components/cards/SwipeCard.tsx
+++ b/src/components/cards/SwipeCard.tsx
@@ -233,7 +233,8 @@ const SwipeIndicator = styled(motion.div)<{ $direction: 'left' | 'right' }>`
   opacity: 0;
 `;
 
-const SWIPE_THRESHOLD = 100;
+const SWIPE_THRESHOLD = 50;
+const VELOCITY_THRESHOLD = 500;
 const SUPER_SWIPE_THRESHOLD = 200;
 
 export const SwipeCard: React.FC<SwipeCardProps> = ({ 
@@ -299,7 +300,7 @@ export const SwipeCard: React.FC<SwipeCardProps> = ({
     }
     
     // Regular horizontal swipes
-    if (Math.abs(xOffset) > SWIPE_THRESHOLD) {
+    if (Math.abs(xOffset) > SWIPE_THRESHOLD || Math.abs(info.velocity.x) > VELOCITY_THRESHOLD) {
       onSwipe(xOffset > 0 ? 'right' : 'left');
     }
   };

--- a/test/swipeProfileAdvance.test.ts
+++ b/test/swipeProfileAdvance.test.ts
@@ -1,0 +1,35 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { useAppStore } from '../src/stores/appStore.ts';
+
+// Ensure swiping a profile advances to the next one
+// and does not create a match for a pass action.
+test('swipeProfile pass advances to next profile without match', () => {
+  const profiles = [
+    {
+      id: '1',
+      name: 'One',
+      age: 20,
+      vibe: 'spicy',
+      bio: '',
+      images: [],
+      personality: { style: '', catchphrase: '', interests: [], signature_move: '' }
+    },
+    {
+      id: '2',
+      name: 'Two',
+      age: 22,
+      vibe: 'chill',
+      bio: '',
+      images: [],
+      personality: { style: '', catchphrase: '', interests: [], signature_move: '' }
+    }
+  ];
+
+  useAppStore.setState({ profiles, currentProfileIndex: 0, matches: [] });
+  const { swipeProfile } = useAppStore.getState();
+  swipeProfile({ type: 'pass', profileId: profiles[0].id, timestamp: new Date() });
+
+  assert.equal(useAppStore.getState().currentProfileIndex, 1);
+  assert.equal(useAppStore.getState().matches.length, 0);
+});


### PR DESCRIPTION
## Summary
- lower card swipe threshold and add velocity trigger
- ensure pass action moves to next profile via test

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af5be8c77483218f9b1308c75ea176