### PR TITLE
Route through splash for vibe selection

### DIFF
--- a/src/pages/EntryScreen.tsx
+++ b/src/pages/EntryScreen.tsx
@@ -5,7 +5,6 @@ import { useNavigate } from 'react-router-dom';
 import { Button } from '../components/common/Button';
 import { useAppStore } from '../stores/appStore';
 import { mockProfiles, mockConversations } from '../data/mockData';
-import { useTheme } from '../styles/themes/ThemeProvider';
 
 const EntryContainer = styled.div`
   height: 100vh;
@@ -115,8 +114,6 @@ const FloatingBackground: React.FC = () => {
 
 export const EntryScreen: React.FC = () => {
   const navigate = useNavigate();
-  const { setVibe } = useTheme();
-  const { setCurrentVibe } = useAppStore();
 
   // Initialize app data when component mounts
   React.useEffect(() => {
@@ -135,7 +132,7 @@ export const EntryScreen: React.FC = () => {
         if (profile) {
           const matchId = `match_${profile.id}`;
           const conversations = mockConversations[profile.id] || [];
-          
+
           useAppStore.setState(state => ({
             matches: [...state.matches, {
               id: matchId,
@@ -146,17 +143,13 @@ export const EntryScreen: React.FC = () => {
           }));
         }
       });
-      
-      // Set default theme to spicy for mixed vibes approach
-      setVibe('spicy');
-      setCurrentVibe('spicy');
     };
-    
+
     initializeApp();
-  }, [setVibe, setCurrentVibe]);
+  }, []);
 
   const handleEnterApp = () => {
-    navigate('/home');
+    navigate('/splash');
   };
 
   return (

--- a/src/pages/SplashScreen.tsx
+++ b/src/pages/SplashScreen.tsx
@@ -3,7 +3,6 @@ import styled from 'styled-components';
 import { motion } from 'framer-motion';
 import { useNavigate } from 'react-router-dom';
 import { useTheme } from '../styles/themes/ThemeProvider';
-import { Button } from '../components/common/Button';
 import type { VibeType } from '../styles/themes/types';
 import { useAppStore } from '../stores/appStore';
 import { mockProfiles, mockConversations } from '../data/mockData';
@@ -124,10 +123,6 @@ const VibeCard = styled(motion.div)<{ $colors: { primary: string; secondary: str
   }
 `;
 
-const StartButton = styled(motion.div)`
-  width: 100%;
-`;
-
 const FloatingBackground: React.FC = () => {
   const emojis = ['🔥', '💎', '🌶️', '🎨', '🏙️', '😌', '💅', '✨', '👑', '🦄'];
   
@@ -203,10 +198,11 @@ export const SplashScreen: React.FC = () => {
     artsy: 'Creative souls and artistic hearts',
     dluxe: 'Luxury lifestyle and high-class sass',
   };
-  
-  const handleEnterApp = () => {
-    setVibe(selectedVibe);
-    setCurrentVibe(selectedVibe);
+
+  const handleVibeSelect = (vibe: VibeType) => {
+    setSelectedVibe(vibe);
+    setVibe(vibe);
+    setCurrentVibe(vibe);
     navigate('/home');
   };
   
@@ -244,12 +240,12 @@ export const SplashScreen: React.FC = () => {
             <VibeCard
               key={vibeKey}
               $colors={{ primary: vibeTheme.colors.primary, secondary: vibeTheme.colors.secondary }}
-              onClick={() => setSelectedVibe(vibeKey as VibeType)}
+              onClick={() => handleVibeSelect(vibeKey as VibeType)}
               whileHover={{ scale: 1.05 }}
               whileTap={{ scale: 0.95 }}
               style={{
                 borderColor: selectedVibe === vibeKey ? vibeTheme.colors.primary : undefined,
-                background: selectedVibe === vibeKey 
+                background: selectedVibe === vibeKey
                   ? `linear-gradient(135deg, ${vibeTheme.colors.primary}40, ${vibeTheme.colors.secondary}40)`
                   : undefined,
               }}
@@ -262,20 +258,6 @@ export const SplashScreen: React.FC = () => {
             </VibeCard>
           ))}
         </VibeSelector>
-        
-        <StartButton
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 1.2, duration: 0.6 }}
-        >
-          <Button
-            size="lg"
-            fullWidth
-            onClick={handleEnterApp}
-          >
-            Enter the VIBES Universe ✨
-          </Button>
-        </StartButton>
       </ContentContainer>
     </SplashContainer>
   );


### PR DESCRIPTION
## Summary
- Remove forced spicy theme and direct entry screen to splash
- Let splash screen vibe cards set and persist theme before routing home

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af66af733483218c3ced8939c6da4f