### PR TITLE
refactor: use viewport units for entry screen

### DIFF
--- a/src/pages/EntryScreen.tsx
+++ b/src/pages/EntryScreen.tsx
@@ -7,16 +7,17 @@ import { useAppStore } from '../stores/appStore';
 import { mockProfiles, mockConversations } from '../data/mockData';
 
 const EntryContainer = styled.div`
+  width: 100vw;
   height: 100vh;
-  max-height: 812px; /* Mobile frame height limit */
-  width: 100%;
-  max-width: 375px; /* Mobile frame width limit */
   background: linear-gradient(135deg, #1a0a1a 0%, #2d1b2e 100%);
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 32px 24px;
+  padding: calc(32px + env(safe-area-inset-top))
+    calc(24px + env(safe-area-inset-right))
+    calc(32px + env(safe-area-inset-bottom))
+    calc(24px + env(safe-area-inset-left));
   position: relative;
   overflow: hidden;
   box-sizing: border-box;
@@ -78,7 +79,7 @@ const CTAButton = styled(motion.div)`
   width: 100%;
   max-width: 280px;
   margin-top: auto;
-  margin-bottom: 60px; /* Space from bottom for mobile frame */
+  margin-bottom: calc(60px + env(safe-area-inset-bottom)); /* Space from bottom for mobile frame */
 `;
 
 const FloatingBackground: React.FC = () => {


### PR DESCRIPTION
## Summary
- expand entry screen container to full viewport width/height
- include safe-area insets for container padding and button margin

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af6a1858408321af27f9856df028d2