### PR TITLE
Use dynamic viewport height with fallback

### DIFF
--- a/src/components/navigation/NavigationLayout.tsx
+++ b/src/components/navigation/NavigationLayout.tsx
@@ -20,7 +20,8 @@ interface NavigationLayoutProps {
 
 const LayoutContainer = styled.div`
   min-height: 100vh;
-  height: 100vh; /* Fixed height for mobile frame */
+  height: 100vh; /* Fallback for browsers without dvh support */
+  height: 100dvh; /* Use dynamic viewport height to cover full screen on modern mobile browsers */
   width: 100%;
   background: ${props => props.theme.current.colors.background};
   display: flex;


### PR DESCRIPTION
## Summary
- support dynamic viewport units for mobile by switching NavigationLayout height to `100dvh` with `100vh` fallback

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af6c64dfc48321b345caa1df9e4749