### PR TITLE
refactor: use MyProfileCard in profile screen

### DIFF
--- a/src/pages/ProfileScreen.tsx
+++ b/src/pages/ProfileScreen.tsx
@@ -1,63 +1,20 @@
 import React from 'react';
 import styled from 'styled-components';
-import { motion } from 'framer-motion';
-import { Edit, Camera, Settings as SettingsIcon } from 'lucide-react';
+import { Edit, Settings as SettingsIcon } from 'lucide-react';
 import { useAppStore } from '../stores/appStore';
 import { useTheme } from '../styles/themes/ThemeProvider';
 import { Button } from '../components/common/Button';
+import { MyProfileCard } from '../components/profile';
 
 const ProfileContainer = styled.div`
   padding: ${props => props.theme.common.spacing.md};
   min-height: calc(100vh - 130px);
 `;
 
-const Header = styled.div`
-  text-align: center;
+const CardWrapper = styled.div`
+  display: flex;
+  justify-content: center;
   margin-bottom: ${props => props.theme.common.spacing.xl};
-`;
-
-const Avatar = styled.div`
-  width: 120px;
-  height: 120px;
-  border-radius: 50%;
-  background: ${props => props.theme.current.gradients.main};
-  margin: 0 auto ${props => props.theme.common.spacing.md};
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 3rem;
-  position: relative;
-`;
-
-const EditAvatarButton = styled(motion.button)`
-  position: absolute;
-  bottom: 0;
-  right: 0;
-  width: 36px;
-  height: 36px;
-  border-radius: 50%;
-  background: ${props => props.theme.current.colors.primary};
-  border: 2px solid ${props => props.theme.current.colors.background};
-  color: white;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-`;
-
-const Name = styled.h1`
-  font-size: ${props => props.theme.common.typography.fontSize.xxl};
-  font-weight: ${props => props.theme.common.typography.fontWeight.bold};
-  color: ${props => props.theme.current.colors.text};
-  margin: 0 0 ${props => props.theme.common.spacing.sm} 0;
-`;
-
-const Bio = styled.p`
-  font-size: ${props => props.theme.common.typography.fontSize.md};
-  color: ${props => props.theme.current.colors.textSecondary};
-  margin: 0;
-  max-width: 300px;
-  margin: 0 auto;
 `;
 
 const VibesSection = styled.div`
@@ -134,20 +91,10 @@ export const ProfileScreen: React.FC = () => {
   
   return (
     <ProfileContainer>
-      <Header>
-        <Avatar>
-          👑
-          <EditAvatarButton
-            whileHover={{ scale: 1.1 }}
-            whileTap={{ scale: 0.9 }}
-          >
-            <Camera size={18} />
-          </EditAvatarButton>
-        </Avatar>
-        <Name>{currentUser.name}</Name>
-        <Bio>{currentUser.bio}</Bio>
-      </Header>
-      
+      <CardWrapper>
+        <MyProfileCard currentUser={currentUser} />
+      </CardWrapper>
+
       <VibesSection>
         <SectionTitle>My Vibes</SectionTitle>
         <VibesList>
@@ -156,9 +103,9 @@ export const ProfileScreen: React.FC = () => {
             return (
               <VibeBadge
                 key={vibeKey}
-                $colors={{ 
-                  primary: vibeTheme.colors.primary, 
-                  secondary: vibeTheme.colors.secondary 
+                $colors={{
+                  primary: vibeTheme.colors.primary,
+                  secondary: vibeTheme.colors.secondary
                 }}
               >
                 {vibeTheme.emoji} {vibeTheme.name}


### PR DESCRIPTION
## Summary
- replace custom profile header with `MyProfileCard`
- keep vibes, stats, and action sections after profile card

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af731c3a088321a7852cae020c9090