### PR TITLE
Use container widths instead of viewport widths

### DIFF
--- a/src/components/cards/SwipeCard.tsx
+++ b/src/components/cards/SwipeCard.tsx
@@ -72,7 +72,7 @@ const CarouselDots = styled.div`
 `;
 
 const Dot = styled.div<{ $active: boolean; $total: number }>`
-  width: ${props => `calc((100vw - 160px) / ${props.$total})`}; /* Adjusted for backdrop padding */
+  width: ${props => `calc((100% - 160px) / ${props.$total})`}; /* Adjusted for backdrop padding */
   max-width: 50px;
   min-width: 20px;
   height: 3px;

--- a/src/components/modals/BingoRewardModal.tsx
+++ b/src/components/modals/BingoRewardModal.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import type { IConfettiOptions } from 'react-confetti';
 import styled from 'styled-components';
 import { AnimatePresence, motion } from 'framer-motion';
 import { X } from 'lucide-react';
@@ -53,14 +54,22 @@ const Message = styled.p`
   color: ${(props) => props.theme.current.colors.text};
 `;
 
+type ConfettiProps = Partial<IConfettiOptions> &
+  React.CanvasHTMLAttributes<HTMLCanvasElement> & { canvasRef?: React.Ref<HTMLCanvasElement> };
+
 export const BingoRewardModal: React.FC<BingoRewardModalProps> = ({ isOpen, onClose }) => {
   const unlockBingoBadge = useAppStore((state) => state.unlockBingoBadge);
-  const [Confetti, setConfetti] = useState<React.ComponentType<unknown> | null>(null);
+  const [Confetti, setConfetti] = useState<React.ComponentType<ConfettiProps> | null>(null);
 
   useEffect(() => {
     let interval: number | undefined;
     if (isOpen && typeof window !== 'undefined') {
-      import('react-confetti').then((mod) => setConfetti(() => mod.default));
+      import('react-confetti').then((mod) =>
+        setConfetti((prev: React.ComponentType<ConfettiProps> | null) => {
+          void prev;
+          return mod.default;
+        })
+      );
       import('canvas-confetti').then((mod) => {
         const duration = 3 * 1000;
         const animationEnd = Date.now() + duration;

--- a/src/index.css
+++ b/src/index.css
@@ -27,7 +27,7 @@ body {
   padding: 0;
   min-width: 320px;
   min-height: 100vh;
-  width: 100vw; /* Full viewport width */
+  width: 100%; /* Full container width */
   height: 100vh;
   overflow: hidden; /* Prevent scrollbars for full screen experience */
   

--- a/src/pages/EntryScreen.tsx
+++ b/src/pages/EntryScreen.tsx
@@ -9,7 +9,7 @@ import { useFullscreen } from '../hooks/useFullscreen';
 import { Maximize2, Minimize2 } from 'lucide-react';
 
 const EntryContainer = styled.div`
-  width: 100vw;
+  width: 100%;
   height: 100vh;
   background: linear-gradient(135deg, #1a0a1a 0%, #2d1b2e 100%);
   display: flex;

--- a/src/pages/HomeScreen.tsx
+++ b/src/pages/HomeScreen.tsx
@@ -21,7 +21,7 @@ const HomeContainer = styled.div`
   flex-direction: column;
   align-items: center;
   position: relative;
-  width: 100vw; /* Full viewport width */
+  width: 100%; /* Use container width */
   margin: 0;
   box-sizing: border-box;
   justify-content: flex-start;
@@ -29,13 +29,13 @@ const HomeContainer = styled.div`
   @media (max-width: 768px) {
     padding: 12px 0 0 0;
     min-height: calc(100vh - 120px);
-    width: 100vw;
+    width: 100%;
   }
 `;
 
 const SwipeArea = styled.div`
   position: relative;
-  width: 100vw; /* Full viewport width */
+  width: 100%; /* Match container width */
   height: 67vh;
   min-height: 510px;
   max-height: 620px;
@@ -44,7 +44,7 @@ const SwipeArea = styled.div`
   box-sizing: border-box;
   
   @media (max-width: 768px) {
-    width: 100vw;
+    width: 100%;
     padding: 0 12px;
   }
 `;
@@ -54,10 +54,10 @@ const ActionButtons = styled.div`
   justify-content: center;
   gap: 18px;
   margin-bottom: ${props => props.theme.common.spacing.lg};
-  width: 100vw;
+  width: 100%;
   padding: 0 24px;
   box-sizing: border-box;
-  max-width: 100vw;
+  max-width: 100%;
   overflow: visible;
   
   @media (max-width: 768px) {
@@ -177,7 +177,7 @@ const MatchNotification = styled(motion.div)`
     padding: ${props => props.theme.common.spacing.md};
   }
   @media (max-width: 375px) {
-    max-width: calc(100vw - 32px);
+    max-width: calc(100% - 32px);
   }
 `;
 


### PR DESCRIPTION
## Summary
- Replace `width: 100vw` with `width: 100%` in global styles
- Update home and entry screen layouts to avoid viewport overflow
- Adjust swipe card dot width calculation to use parent container width
- Type the confetti component in `BingoRewardModal` to satisfy build

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b0535c6f44832196ff020aec800783