### PR TITLE
Ensure match notification fits container

### DIFF
--- a/src/pages/HomeScreen.tsx
+++ b/src/pages/HomeScreen.tsx
@@ -165,7 +165,7 @@ const MatchNotification = styled(motion.div)`
   text-align: center;
   z-index: 100;
   min-width: 280px;
-  max-width: 90vw;
+  max-width: calc(100% - 32px);
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -175,9 +175,6 @@ const MatchNotification = styled(motion.div)`
   @media (max-width: 350px) {
     min-width: 260px;
     padding: ${props => props.theme.common.spacing.md};
-  }
-  @media (max-width: 375px) {
-    max-width: calc(100% - 32px);
   }
 `;
 


### PR DESCRIPTION
## Summary
- keep match notification centered by basing max-width on container padding

## Testing
- `npm test`
- `npm run lint`
- `npm run dev -- --clearScreen false`

------
https://chatgpt.com/codex/tasks/task_e_68b088685644832188f5fecd43186079