### PR TITLE
feat: add Tea Spill screen

### DIFF
--- a/src/components/TeaSpillFeed.tsx
+++ b/src/components/TeaSpillFeed.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import styled from 'styled-components';
+import { mockTeaPosts } from '../data/socialData';
+
+const FeedContainer = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: ${props => props.theme.common.spacing.md};
+`;
+
+const PostCard = styled.div`
+  background: ${props => props.theme.current.colors.surface};
+  padding: ${props => props.theme.common.spacing.md};
+  border-radius: ${props => props.theme.common.borderRadius.medium};
+  display: flex;
+  flex-direction: column;
+  gap: ${props => props.theme.common.spacing.xs};
+`;
+
+const Author = styled.span`
+  font-weight: ${props => props.theme.common.typography.fontWeight.semibold};
+`;
+
+const Content = styled.p`
+  margin: 0;
+  font-size: ${props => props.theme.common.typography.fontSize.sm};
+`;
+
+const Meta = styled.span`
+  font-size: ${props => props.theme.common.typography.fontSize.xs};
+  color: ${props => props.theme.current.colors.textSecondary};
+`;
+
+export const TeaSpillFeed: React.FC = () => (
+  <FeedContainer>
+    {mockTeaPosts.map(post => (
+      <PostCard key={post.id}>
+        <Author>{post.author}</Author>
+        <Content>{post.content}</Content>
+        <Meta>{post.likes} likes</Meta>
+      </PostCard>
+    ))}
+  </FeedContainer>
+);
+

--- a/src/components/navigation/NavigationLayout.tsx
+++ b/src/components/navigation/NavigationLayout.tsx
@@ -192,7 +192,7 @@ const TopBarContent = styled.div`
 
 const navigationItems = [
   { path: '/home', icon: Flame, label: 'Discover' },
-  { path: '/likes', icon: Star, label: 'Likes' },
+  { path: '/tea', icon: Star, label: 'Tea' },
   { path: '/messages', icon: MessageCircle, label: 'Messages' },
   { path: '/communities', icon: Users, label: 'Groups' },
   { path: '/profile', icon: User, label: 'Profile' },

--- a/src/pages/TeaSpillScreen.tsx
+++ b/src/pages/TeaSpillScreen.tsx
@@ -5,8 +5,9 @@ import { useAppStore } from '../stores/appStore';
 import type { VibeType } from '../styles/themes/types';
 import { Button } from '../components/common/Button';
 import BingoRewardModal from '../components/modals/BingoRewardModal';
+import { TeaSpillFeed } from '../components/TeaSpillFeed';
 
-const LikesContainer = styled.div`
+const TeaSpillContainer = styled.div`
   padding: ${props => props.theme.common.spacing.lg};
   min-height: calc(100vh - 130px);
   display: flex;
@@ -55,7 +56,7 @@ const Counts = styled.span`
   font-size: ${props => props.theme.common.typography.fontSize.sm};
 `;
 
-export const LikesScreen: React.FC = () => {
+export const TeaSpillScreen: React.FC = () => {
   const {
     likesGivenByVibe,
     likesReceivedByVibe,
@@ -73,8 +74,9 @@ export const LikesScreen: React.FC = () => {
   }, [likesGivenByVibe, hasBingo, bingoBadgeUnlocked]);
 
   return (
-    <LikesContainer>
-      <Title>Likes</Title>
+    <TeaSpillContainer>
+      <TeaSpillFeed />
+      <Title>Tea Spill</Title>
       <VibeList>
         {vibes.map((vibe) => {
           const given = likesGivenByVibe[vibe];
@@ -103,7 +105,7 @@ export const LikesScreen: React.FC = () => {
         Reset Likes
       </Button>
       <BingoRewardModal isOpen={showModal} onClose={() => setShowModal(false)} />
-    </LikesContainer>
+    </TeaSpillContainer>
   );
 };
 

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -8,7 +8,7 @@ import { MessagesScreen } from './pages/MessagesScreen';
 import { ChatScreen } from './pages/ChatScreen';
 import { ProfileScreen } from './pages/ProfileScreen';
 import { SettingsScreen } from './pages/SettingsScreen';
-import { LikesScreen } from './pages/LikesScreen';
+import { TeaSpillScreen } from './pages/TeaSpillScreen';
 import { CommunitiesScreen } from './pages/CommunitiesScreen';
 
 export const AppRouter: React.FC = () => {
@@ -27,7 +27,7 @@ export const AppRouter: React.FC = () => {
       <Route path="/chat/:matchId" element={<ChatScreen />} />
       <Route path="/profile" element={<ProfileScreen />} />
       <Route path="/settings" element={<SettingsScreen />} />
-      <Route path="/likes" element={<LikesScreen />} />
+      <Route path="/tea" element={<TeaSpillScreen />} />
       <Route path="/communities" element={<CommunitiesScreen />} />
       
       {/* Default redirect */}


### PR DESCRIPTION
## Summary
- rename LikesScreen to TeaSpillScreen and display TeaSpillFeed at top
- add TeaSpillFeed component that lists mock tea posts
- update routes and navigation to use new Tea Spill screen

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0a044450c832188b9d40bc8a3dc8f