### PR TITLE
Add reactions and moderation tools to TeaSpill

### DIFF
--- a/src/components/teaSpill/TeaSpillComposer.tsx
+++ b/src/components/teaSpill/TeaSpillComposer.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
+import { offensiveWords } from '../../data/offensiveWords';
 
 const ComposerForm = styled.form`
   display: flex;
@@ -23,16 +24,30 @@ const Controls = styled.div`
 `;
 
 interface TeaSpillComposerProps {
+  /**
+   * Handler invoked when a new post is submitted.
+   *
+   * @param content - Text body of the post.
+   * @param author - Display name for the post. Use "Anon" to hide identity.
+   */
   onPost: (content: string, author: string) => void;
 }
 
 export const TeaSpillComposer: React.FC<TeaSpillComposerProps> = ({ onPost }) => {
   const [content, setContent] = useState('');
-  const [anonymous, setAnonymous] = useState(false);
+  const [anonymous, setAnonymous] = useState(false); // When true, author is reported as "Anon"
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (!content.trim()) return;
+    const lower = content.toLowerCase();
+    const hasOffensive = offensiveWords.some(word =>
+      lower.includes(word.toLowerCase())
+    );
+    if (hasOffensive) {
+      alert('Please remove offensive language before posting.');
+      return;
+    }
     onPost(content, anonymous ? 'Anon' : 'You');
     setContent('');
     setAnonymous(false);

--- a/src/components/teaSpill/TeaSpillPost.tsx
+++ b/src/components/teaSpill/TeaSpillPost.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 import type { TeaSpillPost as TeaSpillPostType } from '../../data/socialData';
 import { TeaSpillComments } from './TeaSpillComments';
+import { submitReport } from './moderationUtils';
 
 const PostCard = styled.div`
   background: ${props => props.theme.current.colors.surface};
@@ -43,11 +44,25 @@ const Meta = styled.span`
   color: ${props => props.theme.current.colors.textSecondary};
 `;
 
+const Reactions = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: ${props => props.theme.common.spacing.xs};
+  align-items: center;
+`;
+
 const ReactionButton = styled.button`
   background: none;
   border: none;
   cursor: pointer;
   color: ${props => props.theme.current.colors.primary};
+`;
+
+const ReportButton = styled.button`
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: ${props => props.theme.current.colors.textSecondary};
   align-self: flex-start;
 `;
 
@@ -55,8 +70,22 @@ interface TeaSpillPostProps {
   post: TeaSpillPostType;
 }
 
+const defaultReactions = ['👍', '😂', '🔥', '❤️'];
+
 export const TeaSpillPost: React.FC<TeaSpillPostProps> = ({ post }) => {
-  const [likes, setLikes] = useState(post.likes);
+  const [reactions, setReactions] = useState<Record<string, number>>({
+    '👍': post.likes,
+    ...(post.reactions || {}),
+  });
+
+  const addReaction = (key: string) => {
+    setReactions(prev => ({ ...prev, [key]: (prev[key] || 0) + 1 }));
+  };
+
+  const addGifReaction = () => {
+    const url = prompt('GIF URL');
+    if (url) addReaction(url);
+  };
 
   return (
     <PostCard>
@@ -65,9 +94,22 @@ export const TeaSpillPost: React.FC<TeaSpillPostProps> = ({ post }) => {
         <Author>{post.author}</Author>
       </Header>
       <Content>{post.content}</Content>
-      <ReactionButton onClick={() => setLikes(l => l + 1)}>
-        👍 {likes}
-      </ReactionButton>
+      <Reactions>
+        {defaultReactions.map(r => (
+          <ReactionButton key={r} onClick={() => addReaction(r)}>
+            {r} {reactions[r] || 0}
+          </ReactionButton>
+        ))}
+        <ReactionButton onClick={addGifReaction}>GIF</ReactionButton>
+        {Object.entries(reactions).map(([key, count]) => (
+          !defaultReactions.includes(key) && (
+            <ReactionButton key={key} onClick={() => addReaction(key)}>
+              <img src={key} alt="gif" width={20} height={20} /> {count}
+            </ReactionButton>
+          )
+        ))}
+      </Reactions>
+      <ReportButton onClick={() => submitReport(post)}>Report</ReportButton>
       <Meta>{post.timestamp.toLocaleString()}</Meta>
       <TeaSpillComments comments={post.comments} />
     </PostCard>

--- a/src/components/teaSpill/moderationUtils.ts
+++ b/src/components/teaSpill/moderationUtils.ts
@@ -1,0 +1,8 @@
+import type { TeaSpillPost as TeaSpillPostType } from '../../data/socialData';
+
+const reports: TeaSpillPostType[] = [];
+
+export const submitReport = (post: TeaSpillPostType) => {
+  reports.push(post);
+  console.log('Report submitted:', post);
+};

--- a/src/data/offensiveWords.ts
+++ b/src/data/offensiveWords.ts
@@ -1,0 +1,4 @@
+export const offensiveWords = [
+  'badword',
+  'ugly',
+];

--- a/src/data/socialData.ts
+++ b/src/data/socialData.ts
@@ -7,6 +7,7 @@ export interface TeaSpillPost {
   content: string;
   timestamp: Date;
   likes: number;
+  reactions?: Record<string, number>;
   comments: TeaComment[];
   image?: string;
   isHot: boolean; // Featured/trending posts


### PR DESCRIPTION
## Summary
- support multiple emoji and GIF reactions on TeaSpill posts
- add simple post reporting utility
- filter offensive keywords before posting with anonymity docs

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0a3ddf67883218a45d1cf876bc3da