### PR TITLE
Track TeaSpill reactions for vibe bingo

### DIFF
--- a/src/components/teaSpill/TeaSpillFeed.tsx
+++ b/src/components/teaSpill/TeaSpillFeed.tsx
@@ -7,6 +7,8 @@ import {
 import { TeaSpillPost } from './TeaSpillPost';
 import { TeaSpillComposer } from './TeaSpillComposer';
 import { TeaSpillModeration } from './TeaSpillModeration';
+import { useAppStore } from '../../stores/appStore';
+import type { VibeType } from '../../styles/themes/types';
 
 const FeedContainer = styled.div`
   width: 100%;
@@ -18,6 +20,7 @@ const FeedContainer = styled.div`
 export const TeaSpillFeed: React.FC = () => {
   const [posts, setPosts] = useState<TeaSpillPostType[]>(mockTeaPosts);
   const [filter, setFilter] = useState('');
+  const { addLikeGiven, receiveLike, hasBingo } = useAppStore();
 
   const handlePost = (content: string, author: string) => {
     const newPost: TeaSpillPostType = {
@@ -37,6 +40,12 @@ export const TeaSpillFeed: React.FC = () => {
     p.content.toLowerCase().includes(filter.toLowerCase())
   );
 
+  const handleReaction = (vibe: VibeType) => {
+    addLikeGiven(vibe);
+    receiveLike(vibe);
+    hasBingo();
+  };
+
   return (
     <FeedContainer>
       <TeaSpillComposer onPost={handlePost} />
@@ -46,7 +55,7 @@ export const TeaSpillFeed: React.FC = () => {
         onReport={() => alert('Reported')}
       />
       {filtered.map(post => (
-        <TeaSpillPost key={post.id} post={post} />
+        <TeaSpillPost key={post.id} post={post} onReact={handleReaction} />
       ))}
     </FeedContainer>
   );

--- a/src/components/teaSpill/TeaSpillPost.tsx
+++ b/src/components/teaSpill/TeaSpillPost.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
 import type { TeaSpillPost as TeaSpillPostType } from '../../data/socialData';
+import type { VibeType } from '../../styles/themes/types';
 import { TeaSpillComments } from './TeaSpillComments';
 import { submitReport } from './moderationUtils';
 
@@ -68,11 +69,16 @@ const ReportButton = styled.button`
 
 interface TeaSpillPostProps {
   post: TeaSpillPostType;
+  /**
+   * Callback fired whenever a reaction is added so parent components can
+   * update global like counters.
+   */
+  onReact?: (vibe: VibeType) => void;
 }
 
 const defaultReactions = ['👍', '😂', '🔥', '❤️'];
 
-export const TeaSpillPost: React.FC<TeaSpillPostProps> = ({ post }) => {
+export const TeaSpillPost: React.FC<TeaSpillPostProps> = ({ post, onReact }) => {
   const [reactions, setReactions] = useState<Record<string, number>>({
     '👍': post.likes,
     ...(post.reactions || {}),
@@ -80,6 +86,7 @@ export const TeaSpillPost: React.FC<TeaSpillPostProps> = ({ post }) => {
 
   const addReaction = (key: string) => {
     setReactions(prev => ({ ...prev, [key]: (prev[key] || 0) + 1 }));
+    onReact?.(post.vibe);
   };
 
   const addGifReaction = () => {

--- a/src/pages/TeaSpillScreen.tsx
+++ b/src/pages/TeaSpillScreen.tsx
@@ -56,6 +56,10 @@ const Counts = styled.span`
   font-size: ${props => props.theme.common.typography.fontSize.sm};
 `;
 
+const BingoStatus = styled.p`
+  margin: 0;
+`;
+
 export const TeaSpillScreen: React.FC = () => {
   const {
     likesGivenByVibe,
@@ -71,12 +75,13 @@ export const TeaSpillScreen: React.FC = () => {
     if (hasBingo() && !bingoBadgeUnlocked) {
       setShowModal(true);
     }
-  }, [likesGivenByVibe, hasBingo, bingoBadgeUnlocked]);
+  }, [likesGivenByVibe, likesReceivedByVibe, hasBingo, bingoBadgeUnlocked]);
 
   return (
     <TeaSpillContainer>
       <TeaSpillFeed />
       <Title>Tea Spill</Title>
+      <BingoStatus>{hasBingo() ? 'Bingo!' : 'No Bingo yet'}</BingoStatus>
       <VibeList>
         {vibes.map((vibe) => {
           const given = likesGivenByVibe[vibe];


### PR DESCRIPTION
## Summary
- fire onReact callback in TeaSpillPost when a reaction is added
- update TeaSpillFeed to record likes given/received and check bingo
- display live bingo status and re-evaluate on received likes in TeaSpillScreen

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0a769fb748321879254fe28ec5a17